### PR TITLE
Unset `x_static_install`

### DIFF
--- a/META.json
+++ b/META.json
@@ -78,5 +78,5 @@
    },
    "version" : "0.75",
    "x_serialization_backend" : "JSON::PP version 4.11",
-   "x_static_install" : 1
+   "x_static_install" : 0
 }

--- a/META.yml
+++ b/META.yml
@@ -47,4 +47,4 @@ resources:
   repository: git://github.com/Corion/Test-HTTP-LocalServer.git
 version: '0.75'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'
-x_static_install: 1
+x_static_install: 0

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ my %module = (
             license    => "https://dev.perl.org/licenses/",
         },
         dynamic_config   => 0, # we promise to keep META.* up-to-date
-        x_static_install => 1, # we are pure Perl and don't do anything fancy
+        x_static_install => 0,
     },
 
     'LICENSE'=> 'perl',


### PR DESCRIPTION
Because there are non-`*.pm` files that need to be installed under
`lib/`. Otherwise installers that use that setting will not install
`lib/Test/HTTP/log-server`.

Work around is to force those installers to not use the setting:

```sh
$ cpanm --no-static-install Test::HTTP::LocalServer
```
